### PR TITLE
remove deprecated virtual_screen args

### DIFF
--- a/molpal/objectives/__init__.py
+++ b/molpal/objectives/__init__.py
@@ -2,13 +2,16 @@ from typing import Type
 
 from molpal.objectives.base import Objective
 
+
 def objective(objective, objective_config: str, **kwargs) -> Type[Objective]:
     """Objective factory function"""
-    if objective == 'docking':
+    if objective == "docking":
         from molpal.objectives.docking import DockingObjective
+
         return DockingObjective(objective_config, **kwargs)
-    if objective == 'lookup':
+    if objective == "lookup":
         from molpal.objectives.lookup import LookupObjective
+
         return LookupObjective(objective_config, **kwargs)
-    
+
     raise NotImplementedError(f'Unrecognized objective: "{objective}"')

--- a/molpal/objectives/docking.py
+++ b/molpal/objectives/docking.py
@@ -4,10 +4,9 @@ import csv
 from typing import Dict, Iterable, Optional
 
 import numpy as np
+import pyscreener as ps
 
 from molpal.objectives.base import Objective
-
-import pyscreener as ps
 
 
 class DockingObjective(Objective):
@@ -18,7 +17,7 @@ class DockingObjective(Objective):
     ----------
     c : int
         the min/maximization constant, depending on the objective
-    virtual_screen : pyscreener.docking.VirtualScreen
+    virtual_screen : pyscreener.docking.DockingVirtualScreen
         the VirtualScreen object that calculated docking scores of molecules against a given
         receptor with specfied docking parameters
 
@@ -44,7 +43,6 @@ class DockingObjective(Objective):
         minimize: bool = True,
         **kwargs,
     ):
-
         args = ps.args.gen_args(f"--config {objective_config}")
 
         metadata_template = ps.build_metadata(args.screen_type, args.metadata_template)
@@ -61,9 +59,7 @@ class DockingObjective(Objective):
             args.base_name,
             path,
             args.score_mode,
-            args.repeat_score_mode,
             args.ensemble_score_mode,
-            args.repeats,
             args.k,
             verbose,
         )

--- a/molpal/objectives/lookup.py
+++ b/molpal/objectives/lookup.py
@@ -28,10 +28,9 @@ class LookupObjective(Objective):
     **kwargs
         unused and addditional keyword arguments
     """
+
     def __init__(self, objective_config: str, minimize: bool = True, **kwargs):
-        path, delimiter, title_line, smiles_col, score_col = parse_config(
-            objective_config
-        )
+        path, delimiter, title_line, smiles_col, score_col = parse_config(objective_config)
 
         if Path(path).suffix == ".gz":
             open_ = partial(gzip.open, mode="rt")
@@ -88,10 +87,4 @@ def parse_config(config: str):
     parser.add_argument("--score-col", type=int, default=1)
 
     args = parser.parse_args(config)
-    return (
-        args.path,
-        args.sep,
-        not args.no_title_line,
-        args.smiles_col,
-        args.score_col,
-    )
+    return (args.path, args.sep, not args.no_title_line, args.smiles_col, args.score_col)

--- a/molpal/objectives/utils.py
+++ b/molpal/objectives/utils.py
@@ -2,15 +2,17 @@ from itertools import chain, product
 from pathlib import Path
 import tempfile
 from typing import List, Tuple, TypeVar
-T = TypeVar('T')
-U = TypeVar('U')
+
+T = TypeVar("T")
+U = TypeVar("U")
+
 
 def get_temp_file():
     p_tmp = Path(tempfile.gettempdir()) / next(tempfile._get_candidate_names())
     return str(p_tmp)
 
-def distribute_and_flatten(
-        xs_yss: List[Tuple[T, List[U]]]) -> List[Tuple[T, U]]:
+
+def distribute_and_flatten(xs_yss: List[Tuple[T, List[U]]]) -> List[Tuple[T, U]]:
     """Distribute x over a list ys for each item in a list of 2-tuples and
     flatten the resulting lists.
 


### PR DESCRIPTION
## Description
The most recent version of pyscreener deprecated 2 arguments from `ps.virtual_screen`. This PR brings MolPAL's `DockingObjective` up to date with this.

## Example / Current workflow
The current `DockingObjective` will crash on initialization due to a `TypeError` because 2 additional arguments were provided.

## Bugfix / Desired workflow
I removed those 2 deprecated arguments (`repeat_score_mode` and `repeats`)

## Relevant issues
This was raised in [#38](https://github.com/coleygroup/pyscreener/issues/38) on the pyscreener repo.

## Checklist
- [x] linted with flake8?
- [x] (if appropriate) unit tests added?
- [x] **ready to go?**
