### PR TITLE
fix deprecated pyscreener args

### DIFF
--- a/molpal/objectives/docking.py
+++ b/molpal/objectives/docking.py
@@ -58,8 +58,8 @@ class DockingObjective(Objective):
             args.ncpu,
             args.base_name,
             path,
-            args.score_mode,
-            args.ensemble_score_mode,
+            args.reduction,
+            args.receptor_reduction,
             args.k,
             verbose,
         )
@@ -89,7 +89,7 @@ class DockingObjective(Objective):
         return dict(zip(smis, Y))
 
     def cleanup(self):
-        results = self.virtual_screen.all_results()
+        results = self.virtual_screen.results()
         self.virtual_screen.collect_files()
 
         with open(self.virtual_screen.path / "extended.csv", "w") as fid:


### PR DESCRIPTION
bring the `pyscreener` args in the `DockingObjective` up-to-date