### PR TITLE
fix `curr_max` bug with too few scores

### DIFF
--- a/molpal/acquirer/acquirer.py
+++ b/molpal/acquirer/acquirer.py
@@ -252,7 +252,7 @@ class Acquirer:
         if explored:
             ys = list(explored.values())
             Y = np.nan_to_num(np.array(ys, dtype=float), nan=-np.inf)
-            current_max = np.partition(Y, -k)[-k]
+            current_max = np.partition(Y, -k)[-k] if len(Y) >= k else Y.max()
         else:
             explored = {}
             current_max = float("-inf")

--- a/molpal/acquirer/acquirer.py
+++ b/molpal/acquirer/acquirer.py
@@ -251,7 +251,7 @@ class Acquirer:
         """
         if explored:
             ys = list(explored.values())
-            Y = np.nan_to_num(np.array(ys, dtype=float), nan=-np.inf)
+            Y = np.nan_to_num(np.array(ys, float), nan=-np.inf)
             current_max = np.partition(Y, -k)[-k] if len(Y) >= k else Y.max()
         else:
             explored = {}

--- a/molpal/acquirer/metrics.py
+++ b/molpal/acquirer/metrics.py
@@ -47,6 +47,7 @@ def get_needs(metric: str) -> Set:
         "threshold": {"means"},
     }.get(metric, set())
 
+
 def valid_metrics() -> Set[str]:
     return {"random", "threshold", "greedy", "noisy", "ucb", "lcb", "ts", "thompson", "ei", "pi"}
 
@@ -259,7 +260,7 @@ def pi(Y_mean: np.ndarray, Y_var: np.ndarray, current_max: float, xi: float = 0.
         Z = I / np.sqrt(Y_var)
     P_imp = norm.cdf(Z)
 
-    # if expected variance is 0, probability of improvement is 0 or 1 depending on whether the 
+    # if expected variance is 0, probability of improvement is 0 or 1 depending on whether the
     # predicted improvement is <= 0 or >0
     mask = Y_var == 0
     P_imp[mask] = np.where(I > 0, 1, 0)[mask]

--- a/molpal/explorer.py
+++ b/molpal/explorer.py
@@ -265,9 +265,10 @@ class Explorer:
             ave = f"{self.top_k_avg:0.3f}"
         else:
             if len(self.scores) > 0:
-                ave = f"N/A (only {len(self.scores)} scores)"
+                ave = f"{self.avg()} (only {len(self.scores)} scores)"
             else:
                 ave = "N/A (no scores)"
+                
         return (
             f"ITER: {self.iter}/{self.max_iters} | "
             f"TOP-{self.k} AVE: {ave} | "

--- a/molpal/explorer.py
+++ b/molpal/explorer.py
@@ -268,7 +268,7 @@ class Explorer:
                 ave = f"{self.avg()} (only {len(self.scores)} scores)"
             else:
                 ave = "N/A (no scores)"
-                
+
         return (
             f"ITER: {self.iter}/{self.max_iters} | "
             f"TOP-{self.k} AVE: {ave} | "
@@ -469,7 +469,7 @@ class Explorer:
         Returns
         -------
         float
-            the top-k average. NOTE: if there are not at least `k` valid scores, `None` scores will 
+            the top-k average. NOTE: if there are not at least `k` valid scores, `None` scores will
             be included in the top-k as a score of 0 and deflate the top-`k` average.
         """
         k = k or self.k

--- a/molpal/models/mpnn/predict.py
+++ b/molpal/models/mpnn/predict.py
@@ -80,7 +80,7 @@ def predict(
         if scaler:
             preds[:, 0::2] *= scaler.stds
             preds[:, 0::2] += scaler.means
-            preds[:, 1::2] *= scaler.stds ** 2
+            preds[:, 1::2] *= scaler.stds**2
 
         return preds
 

--- a/molpal/models/nnmodels.py
+++ b/molpal/models/nnmodels.py
@@ -178,7 +178,7 @@ class NN:
 
         if self.uncertainty == "mve":
             Y_pred[:, 0::2] = Y_pred[:, 0::2] * self.std + self.mean
-            Y_pred[:, 1::2] = Y_pred[:, 1::2] * self.std ** 2
+            Y_pred[:, 1::2] = Y_pred[:, 1::2] * self.std**2
         else:
             Y_pred = Y_pred * self.std + self.mean
 

--- a/molpal/models/sklmodels.py
+++ b/molpal/models/sklmodels.py
@@ -183,7 +183,7 @@ class GPModel(Model):
         X = np.vstack(xs)
         Y_mean_pred, Y_sd_pred = self.model.predict(X, return_std=True)
 
-        return Y_mean_pred, Y_sd_pred ** 2
+        return Y_mean_pred, Y_sd_pred**2
 
     def save(self, path) -> str:
         path = Path(path)

--- a/molpal/pools/base.py
+++ b/molpal/pools/base.py
@@ -30,21 +30,21 @@ CXSMILES_PATTERN = re.compile(r"\s\|.*\|")
 class MoleculePool(Sequence):
     """A MoleculePool is a sequence of molecules in a virtual chemical library
 
-    By default, a MoleculePool eagerly calculates the uncompressed feature representations of its 
-    entire library and stores these in an hdf5 file. If this is undesired, consider using a 
-    LazyMoleculePool, which calculates these representations only when needed (and recomputes them 
+    By default, a MoleculePool eagerly calculates the uncompressed feature representations of its
+    entire library and stores these in an hdf5 file. If this is undesired, consider using a
+    LazyMoleculePool, which calculates these representations only when needed (and recomputes them
     as necessary.)
 
-    A MoleculePool is most accurately described as a Sequence of Mols, and the custom class is 
-    necessary for both utility and memory purposes. Its main purpose is to hide the storage of 
+    A MoleculePool is most accurately described as a Sequence of Mols, and the custom class is
+    necessary for both utility and memory purposes. Its main purpose is to hide the storage of
     large numbers of SMILES strings and molecular fingerprints on disk.
 
     Attributes
     ----------
     libraries : str
-        the filepaths of (compressed) CSVs containing the pool members. NOTE: each file must be in 
-        the same format. That is, if the first file is a TSV of CXSMILES strings with no title 
-        line, then the second file must also be a TSV of CXSMILES strings with no title line, and 
+        the filepaths of (compressed) CSVs containing the pool members. NOTE: each file must be in
+        the same format. That is, if the first file is a TSV of CXSMILES strings with no title
+        line, then the second file must also be a TSV of CXSMILES strings with no title line, and
         so on for each successive file.
     size : int
         the total number of molecules in the pool
@@ -76,10 +76,10 @@ class MoleculePool(Sequence):
     delimiter : str, default=','
     smiles_col : int, default=0
     fps : Optional[str], default=None
-        the filepath of an hdf5 file containing the precomputed fingerprints. If specified, a user 
+        the filepath of an hdf5 file containing the precomputed fingerprints. If specified, a user
         assumes the following:
         1. the ordering of the fingerprints matches the ordering in the library file
-        2. the featurizer used to generate the fingerprints is the same as the one passed to the 
+        2. the featurizer used to generate the fingerprints is the same as the one passed to the
             model
         If None, the MoleculePool will generate this file automatically
     featurizer : Featurizer, default=Featurizer()
@@ -87,15 +87,15 @@ class MoleculePool(Sequence):
     cache : bool, default=False
         whether to cache the SMILES strings in memory
     validated : bool, default=False
-        whether the pool has been validated already. If True, the user accepts the risk of an 
-        invalid molecule raising an exception later on. Mostly useful for multiple runs on a pool 
+        whether the pool has been validated already. If True, the user accepts the risk of an
+        invalid molecule raising an exception later on. Mostly useful for multiple runs on a pool
         that has been manually validated and pruned.
     cluster : bool, default=False
         whether to cluster the library
     ncluster : int, default=100
         the number of clusters to form. Only used if cluster is True
     fps_path : Optional[str], default=None
-        the path under which the HDF5 file should be written. By default, will write the 
+        the path under which the HDF5 file should be written. By default, will write the
         fingerprints HDF5 file under the same directory as the first library file
     verbose : int, default=0
     **kwargs
@@ -156,7 +156,7 @@ class MoleculePool(Sequence):
     def __iter__(self) -> Iterator[Mol]:
         """Return an iterator over the molecule pool.
 
-        NOTE: Not recommended for use in open constructs. I.e., don't explicitly call this method 
+        NOTE: Not recommended for use in open constructs. I.e., don't explicitly call this method
         unless you plan to exhaust the full iterator.
         """
         return zip(self.smis(), self.fps(), self.cluster_ids() or repeat(None))
@@ -325,7 +325,7 @@ class MoleculePool(Sequence):
             return fps[idxs]
 
     def get_cluster_ids(self, idxs: Sequence[int]) -> Optional[List[int]]:
-        """Get the cluster_ids for the given indices, if the pool is clustered. Otherwise, return 
+        """Get the cluster_ids for the given indices, if the pool is clustered. Otherwise, return
         None
 
         NOTE: Returns the list in sorted index order
@@ -425,7 +425,7 @@ class MoleculePool(Sequence):
                 yield fps[i : i + self.chunk_size]
 
     def cluster_ids(self) -> Optional[Iterator[int]]:
-        """If the pool is clustered, return a generator over pool inputs' cluster IDs. Otherwise, 
+        """If the pool is clustered, return a generator over pool inputs' cluster IDs. Otherwise,
         return None"""
         if self.cluster_ids_:
 

--- a/tests/test_acquirer.py
+++ b/tests/test_acquirer.py
@@ -1,3 +1,4 @@
+from random import random
 import string
 import uuid
 
@@ -6,50 +7,63 @@ import pytest
 
 from molpal.acquirer import Acquirer
 
+
 @pytest.fixture(
-    params=[list(string.printable), list(range(50)), list(str(uuid.uuid4())+str(uuid.uuid4()))]
+    params=[list(string.printable), list(range(50)), list(str(uuid.uuid4()) + str(uuid.uuid4()))]
 )
 def xs(request):
     return request.param
+
+
+@pytest.fixture(params=2 ** np.arange(4))
+def explored(xs, request):
+    idxs = np.random.choice(len(xs), request.param)
+
+    return {xs[i]: random() for i in idxs}
+
 
 @pytest.fixture
 def Y_mean(xs):
     return np.random.normal(len(xs), size=len(xs))
 
+
 @pytest.fixture
 def Y_var(xs):
     return np.random.normal(size=len(xs)) / 10
+
 
 @pytest.fixture
 def init_size():
     return 10
 
+
 @pytest.fixture
 def batch_sizes():
     return [10]
+
 
 @pytest.fixture(params=[None, 42])
 def seed(request):
     return request.param
 
+
 @pytest.fixture
 def acq(xs, init_size, batch_sizes, seed):
-    return Acquirer(len(xs), init_size, batch_sizes, 'greedy', seed=seed)
+    return Acquirer(len(xs), init_size, batch_sizes, "greedy", seed=seed)
 
-@pytest.fixture(params=[0., 0.1, 0.5, 1.])
-def epsilon(request):
-    return request.param
 
 def test_acquire_initial(acq, xs):
     xs_0 = acq.acquire_initial(xs)
 
     assert len(xs_0) == acq.init_size
 
+
 def test_acquire_initial_reacquire(acq, xs):
     xs_0 = acq.acquire_initial(xs)
     xs_1 = acq.acquire_initial(xs)
 
     assert xs_0 != xs_1
+
 
 def test_acquire_initial_reacquire_seeded(acq, xs, seed):
     if seed is None:
@@ -61,37 +75,59 @@ def test_acquire_initial_reacquire_seeded(acq, xs, seed):
 
     assert xs_0 == xs_1
 
-def test_acquire_batch_unexplored(acq, xs, Y_mean, Y_var):
-    init_xs = acq.acquire_initial(xs)
-    explored = {x: 0. for x in init_xs}
 
-    batch_xs = acq.acquire_batch(xs, Y_mean, Y_var, explored)
+def test_acquire_batch_size(acq, xs, Y_mean, Y_var, explored):
+    batch = acq.acquire_batch(xs, Y_mean, Y_var, explored)
 
-    assert len(batch_xs) == acq.batch_sizes[0]
-    assert set(init_xs) != set(batch_xs)
+    assert len(batch) == acq.batch_sizes[0]
+
+
+def test_acquire_batch_unique(acq, xs, Y_mean, Y_var, explored):
+    batch = acq.acquire_batch(xs, Y_mean, Y_var, explored)
+
+    assert all(x not in explored for x in batch)
+
+
+@pytest.mark.parametrize("k", [0, 0.5, 2])
+def test_acquire_batch_k(acq: Acquirer, xs, Y_mean, Y_var, explored, k):
+    k = min(1, int(k * len(explored)))
+    batch = acq.acquire_batch(xs, Y_mean, Y_var, explored, k)
+
+    assert all(x not in explored for x in batch)
+
 
 def test_acquire_batch_top_m(acq, xs, Y_mean, Y_var):
-    batch_xs = acq.acquire_batch(xs, Y_mean, Y_var, {})
+    batch = acq.acquire_batch(xs, Y_mean, Y_var, None)
 
-    top_m_idxs = np.argsort(Y_mean)[:-1 - acq.batch_sizes[0]:-1]
-    top_m_xs = np.array(xs)[top_m_idxs]
+    top_m_idxs = np.argsort(Y_mean)[: -1 - acq.batch_sizes[0] : -1]
+    top_m_xs = [xs[i] for i in top_m_idxs]
 
-    assert len(batch_xs) == len(top_m_xs)
-    assert set(batch_xs) == set(top_m_xs)
+    assert all(x in top_m_xs for x in batch)
 
-def test_aquire_batch_epsilon(acq, xs, Y_mean, Y_var, epsilon):
-    """this test may randomly fail but the chances of that are low.
-    repeated failures indicate problems"""
+
+def test_acquire_batch_determinism(acq, xs, Y_mean, Y_var):
+    acq.epsilon = 0
+
+    batch_1 = acq.acquire_batch(xs, Y_mean, Y_var, None)
+    batch_2 = acq.acquire_batch(xs, Y_mean, Y_var, None)
+
+    assert batch_1 == batch_2
+
+
+@pytest.mark.parametrize("epsilon", [0.1, 0.5, 1.0])
+def test_aquire_batch_nondetermism(acq, xs, Y_mean, Y_var, epsilon):
+    """this test may randomly fail but the chances of that are low. repeated failures indicate
+    problems"""
     acq.epsilon = epsilon
-    batch_xs_0 = acq.acquire_batch(xs, Y_mean, Y_var, {})
-    batch_xs_1 = acq.acquire_batch(xs, Y_mean, Y_var, {})
+    batch_1 = acq.acquire_batch(xs, Y_mean, Y_var, None)
+    batch_2 = acq.acquire_batch(xs, Y_mean, Y_var, None)
 
-    top_m_idxs = np.argsort(Y_mean)[:-1 - acq.batch_sizes[0]:-1]
+    top_m_idxs = np.argsort(Y_mean)[: -1 - acq.batch_sizes[0] : -1]
     top_m_xs = np.array(xs)[top_m_idxs]
 
-    assert len(batch_xs_0) == len(top_m_xs)
-    if epsilon == 0.:
-        assert batch_xs_0 == batch_xs_1
+    assert len(batch_1) == len(batch_2) == len(top_m_xs)
+
+    if epsilon == 0.0:
+        assert batch_1 == batch_2
     else:
-        assert batch_xs_0 != batch_xs_1
-        
+        assert batch_1 != batch_2


### PR DESCRIPTION
## Description
in `Acquirer.acquire_batch` there is a bug when `explored` is not `None` but does not contain at least `k` scores. This PR addresses that.

## Current bug
the `current_max` is currently determined using `np.partition` to find the `k`th best score without sorting the full array of input scores. However, this will raise a `ValueError` when the length of that array is less than `k`.

## Fix
A simple ternary statement: `curr_max = np.partition(Y, -k)[-k] if len(Y) >= k else Y.max()` covers all cases

## Notes
This PR also formats a few extraneous files

## Relevant issues
N/A

## Checklist
- [x] linted with flake8?
- [x] (if appropriate) unit tests added?
- [x] **ready to go?**
