### PR TITLE
Bug/ray remotes

### DIFF
--- a/molpal/explorer.py
+++ b/molpal/explorer.py
@@ -265,7 +265,7 @@ class Explorer:
             ave = f"{self.top_k_avg:0.3f}"
         else:
             if len(self.scores) > 0:
-                ave = f"{self.avg()} (only {len(self.scores)} scores)"
+                ave = f"{self.avg():0.3f} (only {len(self.scores)} scores)"
             else:
                 ave = "N/A (no scores)"
 

--- a/molpal/models/base.py
+++ b/molpal/models/base.py
@@ -66,7 +66,7 @@ class Model(ABC):
     def train(
         self,
         xs: Iterable[T],
-        ys: Sequence[float],
+        ys: np.ndarray,
         *,
         featurizer: Callable[[T], T_feat],
         retrain: bool = False,
@@ -77,9 +77,8 @@ class Model(ABC):
         ----------
         xs : Iterable[T]
             an iterable of inputs in their identifier representation
-        ys : Sequence[float]
-            a parallel sequence of scalars that correspond to the regression
-            target for each x
+        ys : np.ndarray
+            a parallel ndarray of target regression values
         featurize : Callable[[T], T_feat]
             a function that transforms an input from its identifier to its
             feature representation

--- a/molpal/models/mpnmodels.py
+++ b/molpal/models/mpnmodels.py
@@ -111,16 +111,16 @@ class MPNN:
         self.precision = precision
 
         self.model = mpnn.MoleculeModel(
-            uncertainty=uncertainty,
-            dataset_type=dataset_type,
-            num_tasks=num_tasks,
-            atom_messages=atom_messages,
-            hidden_size=hidden_size,
-            bias=bias,
-            depth=depth,
-            dropout=dropout,
-            undirected=undirected,
+            uncertainty,
+            dataset_type,
+            num_tasks,
+            atom_messages,
+            bias,
+            depth,
+            dropout,
+            undirected,
             activation=activation,
+            hidden_size=hidden_size,
             ffn_hidden_size=ffn_hidden_size,
             ffn_num_layers=ffn_num_layers,
         )
@@ -137,11 +137,11 @@ class MPNN:
         ngpu = int(ray.cluster_resources().get("GPU", 0))
         if ngpu > 0:
             self.use_gpu = True
-            self._predict = ray.remote(num_cpus=ncpu, num_gpus=1)(mpnn.predict)
+            self._predict = mpnn.predict_.options(num_cpus=ncpu, num_gpus=1)
             self.num_workers = ngpu
         else:
             self.use_gpu = False
-            self._predict = ray.remote(num_cpus=ncpu)(mpnn.predict)
+            self._predict = mpnn.predict_.options(num_cpus=ncpu)
             self.num_workers = int(ray.cluster_resources()["CPU"] // self.ncpu)
 
         self.seed = model_seed
@@ -161,7 +161,7 @@ class MPNN:
             "metric": metric,
         }
 
-    def train(self, smis: Iterable[str], targets: Sequence[float]) -> bool:
+    def train(self, smis: Iterable[str], targets: np.ndarray) -> bool:
         """Train the model on the inputs SMILES with the given targets"""
         train_data, val_data = self.make_datasets(smis, targets)
 
@@ -180,10 +180,10 @@ class MPNN:
             return True
 
         train_dataloader = MoleculeDataLoader(
-            dataset=train_data, batch_size=self.batch_size, num_workers=self.ncpu, pin_memory=False
+            train_data, self.batch_size, self.ncpu, pin_memory=False
         )
         val_dataloader = MoleculeDataLoader(
-            dataset=val_data, batch_size=self.batch_size, num_workers=self.ncpu, pin_memory=False
+            val_data, self.batch_size, self.ncpu, pin_memory=False
         )
 
         lit_model = mpnn.ptl.LitMPNN(self.train_config)
@@ -235,10 +235,12 @@ class MPNN:
         Returns
         -------
         np.ndarray
-            the array of predictions with shape NxO, where N is the number of
-            inputs and O is the number of tasks."""
+            an array of shape `n x m`, where `n` is the number of SMILES strings and `m` is the
+            number of tasks
+        """
         model = ray.put(self.model)
         scaler = ray.put(self.scaler)
+
         refs = [
             self._predict.remote(
                 model,
@@ -252,8 +254,17 @@ class MPNN:
             )
             for smis in batches(smis, 20000)
         ]
-        preds_chunks = [ray.get(r) for r in tqdm(refs, "Prediction", unit="chunk", leave=False)]
-        return np.concatenate(preds_chunks)
+        Y_pred_batches = [ray.get(r) for r in tqdm(refs, "Prediction", unit="batch", leave=False)]
+        Y_pred = np.concatenate(Y_pred_batches)
+
+        if self.scaler is not None:
+            if self.uncertainty == "mve":
+                Y_pred[:, 0::2] = Y_pred[:, 0::2] * self.scaler.stds + self.scaler.means
+                Y_pred[:, 1::2] *= self.scaler.stds**2
+            else:
+                Y_pred = Y_pred * self.scaler.stds + self.scaler.means
+
+        return Y_pred
 
     def save(self, path) -> str:
         path = Path(path)
@@ -271,6 +282,7 @@ class MPNN:
             }
         except AttributeError:
             state = {"model_path": model_path}
+
         json.dump(state, open(state_path, "w"), indent=4)
 
         return state_path
@@ -316,7 +328,7 @@ class MPNModel(Model):
         return "mpn"
 
     def train(
-        self, xs: Iterable[str], ys: Sequence[float], *, retrain: bool = False, **kwargs
+        self, xs: Iterable[str], ys: np.ndarray, *, retrain: bool = False, **kwargs
     ) -> bool:
         if retrain:
             self.model = self.build_model()
@@ -378,7 +390,7 @@ class MPNDropoutModel(Model):
         return {"means", "vars", "stochastic"}
 
     def train(
-        self, xs: Iterable[str], ys: Sequence[float], *, retrain: bool = False, **kwargs
+        self, xs: Iterable[str], ys: np.ndarray, *, retrain: bool = False, **kwargs
     ) -> bool:
         if retrain:
             self.model = self.build_model()
@@ -437,7 +449,7 @@ class MPNTwoOutputModel(Model):
         return {"means", "vars"}
 
     def train(
-        self, xs: Iterable[str], ys: Sequence[float], *, retrain: bool = False, **kwargs
+        self, xs: Iterable[str], ys: np.ndarray, *, retrain: bool = False, **kwargs
     ) -> bool:
         if retrain:
             self.model = self.build_model()

--- a/molpal/models/mpnmodels.py
+++ b/molpal/models/mpnmodels.py
@@ -209,10 +209,16 @@ class MPNN:
         self, xs: Iterable[str], ys: np.ndarray
     ) -> Tuple[MoleculeDataset, MoleculeDataset]:
         """Split xs and ys into train and validation datasets"""
-        data = MoleculeDataset(
-            [MoleculeDatapoint(smiles=[x], targets=y) for x, y in zip(xs, np.atleast_2d(ys))]
-        )
-        train_data, val_data, _ = split_data(data, "random", (0.8, 0.2, 0.0), seed=self.seed)
+        if len(ys.shape) == 1:
+            data = MoleculeDataset(
+                [MoleculeDatapoint(smiles=[x], targets=[y]) for x, y in zip(xs, ys)]
+            )
+        else:
+            data = MoleculeDataset(
+                [MoleculeDatapoint(smiles=[x], targets=y) for x, y in zip(xs, ys)]
+            )
+        train_data, val_data, _ = split_data(data, sizes=(0.8, 0.2, 0.0), seed=self.seed)
+
         self.scaler = train_data.normalize_targets()
         val_data.scale_targets(self.scaler)
 

--- a/molpal/models/mpnn/__init__.py
+++ b/molpal/models/mpnn/__init__.py
@@ -1,5 +1,5 @@
 from .evaluate import evaluate
 from .model import MoleculeModel
-from .predict import predict
+from .predict import predict, predict_
 from .train import train
 from . import ptl, ray, utils

--- a/molpal/models/mpnn/ptl/model.py
+++ b/molpal/models/mpnn/ptl/model.py
@@ -75,8 +75,6 @@ class LitMPNN(pl.LightningModule):
         if self.uncertainty == "mve":
             Y_pred = Y_pred[:, 0::2]
 
-        Y = torch.tensor(Y, device=self.device)
-
         return self.metric(Y_pred, Y)
 
     def validation_epoch_end(self, outputs):

--- a/molpal/objectives/lookup.py
+++ b/molpal/objectives/lookup.py
@@ -2,7 +2,7 @@ import csv
 from functools import partial
 import gzip
 from pathlib import Path
-from typing import Collection, Dict, Optional
+from typing import Dict, Iterable, Optional
 
 from configargparse import ArgumentParser
 from tqdm import tqdm
@@ -43,7 +43,7 @@ class LookupObjective(Objective):
             if title_line:
                 next(fid)
 
-            for row in tqdm(reader, desc="Building oracle", leave=False):
+            for row in tqdm(reader, "Building oracle", leave=False):
                 key = row[smiles_col]
                 val = row[score_col]
                 try:
@@ -53,7 +53,7 @@ class LookupObjective(Objective):
 
         super().__init__(minimize=minimize)
 
-    def forward(self, smis: Collection[str], *args, **kwargs) -> Dict[str, Optional[float]]:
+    def forward(self, smis: Iterable[str], *args, **kwargs) -> Dict[str, Optional[float]]:
         return {smi: self.c * self.data[smi] if smi in self.data else None for smi in smis}
 
 


### PR DESCRIPTION
## Description
This PR changes the manner in which MPNN prediction is chunked out over the `ray` cluster

## Current workflow
To distribute molecular prediction across the ray cluster, a `ray.remote` function is created from `mpnn.predict` during `MPNN` initialization:
```python
if ngpu > 0:
    self.use_gpu = True
    self._predict = ray.remote(num_cpus=ncpu, num_gpus=1)(mpnn.predict)
    self.num_workers = ngpu
else:
    self.use_gpu = False
    self._predict = ray.remote(num_cpus=ncpu)(mpnn.predict)
    self.num_workers = int(ray.cluster_resources()["CPU"] // self.ncpu) 
```

However, this is a suboptimal code structure as `ray.remote` functions are intended to be defined at the module level and a *similar* remote function is created in the `ray` cluster **every time** an `MPNN` object is initialized. The intention with this block hinges on the word "similar". The core logic of the remote function that's created is the *same* (i.e,. it's just the remote function of `mpnn.predict`,) but the *resources* of the remote function is *different*, hence the definition at object initialization. There are currently some obscure runtime errors where a remote function is ejected from memory and the whole of MolPAL crashes and I suspect this block might be a culprit. Even if it's not, it's still worthwhile to change it.

## New workflow
Now, we rely on the fact that we can create a parent remote function that permanently lives in the `ray` cluster and dynamically define children that modify the resources required to run it (because we can't know before runtime how many CPUs / GPUs the function should be run over). We change the above block to the following:
```python
if ngpu > 0:
    self.use_gpu = True
    self._predict = mpnn.predict_.options(num_cpus=ncpu, num_gpus=1)
    self.num_workers = ngpu
else:
    self.use_gpu = False
    self._predict = mpnn.predict_.options(num_cpus=ncpu)
    self.num_workers = int(ray.cluster_resources()["CPU"] // self.ncpu) 
```

Creating a **new** remote function is relatively expensive, but creating a **child** remote function that just alters resource requirements should be fairly cheap. I would also argue that this code is slightly less obscure than above and can useful in a new convention in the codebase: annotating global remote functions with a succeeding `_`. I.e., if we have a function `foo()` and we want to run it remotely, we know then to call the function `foo_.remote()`

## Checklist
- [x] linted with flake8?
- [x] (if appropriate) unit tests added?
- [x] **ready to go?**
