### PR TITLE
add rdkit to config files

### DIFF
--- a/.github/test-env.yaml
+++ b/.github/test-env.yaml
@@ -8,13 +8,13 @@ dependencies:
   - pytorch::pytorch >=1.10
   - pytorch::cpuonly
   - pip
-  - rdkit
   - pip:
     - configargparse
     - h5py
     - numpy
     - ray >= 1.11
     - ray[tune]
+    - rdkit
     - pytest
     - pytorch-lightning
     - scikit-learn

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8]
+        python-version: [3.8]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,6 @@ dependencies:
   - cudatoolkit=11.3
   - python=3.8
   - pytorch::pytorch >=1.10
-  - rdkit
   - pip
   - pip:
     - configargparse
@@ -16,6 +15,7 @@ dependencies:
     - numpy
     - ray >= 1.11
     - ray[tune]
+    - rdkit
     - pytorch-lightning
     - scikit-learn
     - tensorflow

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,12 +15,13 @@ platforms = Linux, Mac OS-X, Unix
 [options]
 include_package_data = True
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires = 
 	configargparse
 	h5py
 	numpy
 	ray[default] >= 1.11
+	rdkit
 	scikit_learn
 	tensorflow
 	tensorflow_addons


### PR DESCRIPTION
## Description
This PR adds `rdkit` to the list of package requiremnts in `setup.cfg`

## Example / Current workflow
Prior to a few months ago, RDKit was not pip-installable. Now it is, so we should support that.

## Bugfix / Desired workflow
moved `rdkit` from `conda` to `pip` dependencies and made it a requirement in `setup.cfg`

## Checklist
- [x] linted with flake8?
- [x] (if appropriate) unit tests added?
- [x] **ready to go?**
